### PR TITLE
Fix some login exceptions

### DIFF
--- a/twspace_dl/login.py
+++ b/twspace_dl/login.py
@@ -68,9 +68,11 @@ class Login:
         try:
             self.flow_token = request_flow.json()["flow_token"]
         except KeyError as err:
-            raise RuntimeError(
-                "Error while checking account duplication:", request_flow.json()
-            ) from err
+            pass
+            # Sometimes it doesn't check account duplication
+            # raise RuntimeError(
+            #     "Error while checking account duplication:", request_flow.json()
+            # ) from err
 
         # enter password
         request_flow = self.session.post(

--- a/twspace_dl/login.py
+++ b/twspace_dl/login.py
@@ -64,11 +64,9 @@ class Login:
         # account duplication check
         request_flow = self.session.post(
             self.task_url, headers=self._headers, json=self._account_dup_check_data
-        )
-        try:
-            self.flow_token = request_flow.json()["flow_token"]
-        except KeyError as err:
-            pass
+        ).json()
+        if "flow_token" in request_flow.keys():
+            self.flow_token = request_flow["flow_token"]
             # Sometimes it doesn't check account duplication
             # raise RuntimeError(
             #     "Error while checking account duplication:", request_flow.json()


### PR DESCRIPTION
It seems that twitter checks account duplication, but not always.
We can check this by `subtasks` from response json object, but just pass the exceptions should be work too.