### PR TITLE
Rewrite the docker-compose monitoring solution

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 # Twitter username from url, e.g. https://twitter.com/OOXXOOXX
 TWITTER_ID=OOXXOOXX
-# COOKIE=/path/to/cookies.txt
+INTERVAL=30

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 tmp
 __pycache__
 .python-version
+cookies.txt

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Using a cookie can help solve some problem with the twitter api. However, using 
 
 #### Without cookie
 
-1. Download the `docker-compose.yml` and `.env` files and put them in a folder named `twspace-dl`.
+1. Download the `docker-compose.yml`, `.env`, `monitor.sh` files and put them in a folder named `twspace-dl`.
 2. Edit `.env` and fill in the Twitter username you want to monitor.
 3. \[Optional] If you want to used a cookies file, put it into the folder and named it `cookies.txt`.
 4. `docker-compose up -d`

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ You can use the following identifiers for the formatting
 %(url)s
 ```
 
-Example: `[%(creator_screen_name)s]-%(title)s|%(start_date)s`
+Example: `[%(creator_screen_name)s]-%(title)s|%(start_date)s`
 
 ## Service
 
@@ -196,11 +196,8 @@ docker run --rm -v ${pwd}:/output ryu1845/twspace-dl -i space_url
 Using a cookie can help solve some problem with the twitter api. However, using one is not necessary.
 
 #### Without cookie
+
 1. Download the `docker-compose.yml` and `.env` files and put them in a folder named `twspace-dl`.
 2. Edit `.env` and fill in the Twitter username you want to monitor.
-3. `docker-compose up -d`
-
-#### With cookies.txt
-1. Download the `docker-compose.yml`, `docker-compose.cookie.yml` and `.env` files and put them in a folder named `twspace-dl`.
-2. Edit `.env` and fill in the Twitter username you want to monitor and the path of your cookies.
-3. `docker-compose -f docker-compose.yml -f docker-compose.cookie.yml up -d`
+3. \[Optional] If you want to used a cookies file, put it into the folder and named it `cookies.txt`.
+4. `docker-compose up -d`

--- a/docker-compose.cookie.yml
+++ b/docker-compose.cookie.yml
@@ -1,6 +1,0 @@
-services:
-  twspace-dl:
-      command: ["-U", "https://twitter.com/${TWITTER_ID}", "--input-cookie-file", "/cookies.txt"]
-      volumes:
-        - ./:/output
-        - ${COOKIE}:/cookies.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,21 +8,9 @@ services:
     env_file: .env
     volumes:
       - ./:/output
-    command: ["-U", "https://twitter.com/${TWITTER_ID}"]
+    entrypoint: [ "/usr/bin/dumb-init", "--", "sh" ]
+    command: [ "monitor.sh" ]
     # logging:
     #   driver: "gelf"
     #   options:
     #     gelf-address: "udp://127.0.0.1:12201"
-
-  jobber:
-    image: blacklabelops/jobber:docker
-    restart: always
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./:/twspace-dl:ro
-    environment:
-      - JOB_NAME1=record
-      - JOB_COMMAND1=cd /twspace-dl && docker-compose start twspace-dl
-      - JOB_TIME1=*/30 * * * * * #Every 30 seconds
-      - JOB_NOTIFY_ERR1=false
-      - JOB_NOTIFY_FAIL1=false

--- a/monitor.sh
+++ b/monitor.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Twitter space Recorder
+# This script is designd for docker-compose.
+
+if [ -z "$TWITTER_ID" ]; then
+  echo "This script is designd for docker-compose."
+  exit 1
+fi
+
+INTERVAL=${INTERVAL:-10}
+COOKIES_PATH="/output/cookies.txt"
+
+# Monitor live streams of specific user
+while true; do
+  LOG_PREFIX=$(date +"[%m/%d/%y %H:%M:%S] [tw_space@${TWITTER_ID}] ")
+
+  # Start recording
+  if [ ! -f "$COOKIES_PATH" ]; then
+    echo "$LOG_PREFIX [VRB] Start trying..."  
+    /venv/bin/twspace_dl -U "https://twitter.com/${TWITTER_ID}" --write-url "master_urls.txt"
+  else
+    echo "$LOG_PREFIX [VRB] Start trying with cookies..."
+    /venv/bin/twspace_dl -U "https://twitter.com/${TWITTER_ID}" --write-url "master_urls.txt" --input-cookie-file "$COOKIES_PATH" -o "$COOKIES_PATH"
+  fi
+
+  echo "$LOG_PREFIX [VRB] Sleep $INTERVAL sec."
+  sleep "$INTERVAL"
+done


### PR DESCRIPTION
Every once in a while since deploying, my host is getting unresponsive from the docker program. \
I speculate that the use of frequent docker start is inappropriate. So I rewrite the motoring solution.

Notice that I changed the way with `cookies.txt` as I wrote in README.md

- \[Optional] If you want to used a cookies file, put it into the folder and named it `cookies.txt`.

It will be much simpler.