### PR TITLE
strftime didn't have %s and log file problem

### DIFF
--- a/twspace_dl/__main__.py
+++ b/twspace_dl/__main__.py
@@ -32,7 +32,7 @@ def space(args: argparse.Namespace) -> None:
 
     if args.log:
         log_filename = datetime.datetime.now().strftime(
-            ".twspace-dl.%Y-%m-%d_%H-%M-%S_%s.log"
+            ".twspace-dl.%Y-%m-%d_%H-%M-%S_%f.log"
         )
         handlers = [
             logging.FileHandler(log_filename),

--- a/twspace_dl/__main__.py
+++ b/twspace_dl/__main__.py
@@ -83,7 +83,7 @@ def space(args: argparse.Namespace) -> None:
         print(twspace_dl.master_url)
     if args.write_url:
         with open(args.write_url, "a", encoding="utf-8") as url_output:
-            url_output.write(twspace_dl.master_url)
+            url_output.write(twspace_dl.master_url + "\n")
     if args.write_playlist:
         twspace_dl.write_playlist()
 


### PR DESCRIPTION
[strftime() Format Codes](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes) didn't have `%s` and maybe means `%f Microsecond as a decimal number, zero-padded to 6 digits.` ?
https://github.com/Ryu1845/twspace-dl/blob/daa6ab1d1fdf5f56f4b6d95717a5c0295d8b50cc/twspace_dl/__main__.py#L35
And this is the error that use `%s`
```cmd
Traceback (most recent call last):
  File "c:\users\test01\appdata\local\programs\python\python39\lib\runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "c:\users\test01\appdata\local\programs\python\python39\lib\runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "C:\Users\test01\AppData\Local\Programs\Python\Python39\Scripts\twspace_dl.exe\__main__.py", line 7, in <module>
  File "c:\users\test01\appdata\local\programs\python\python39\lib\site-packages\twspace_dl\__main__.py", line 199, in main
    args.func(args)
  File "c:\users\test01\appdata\local\programs\python\python39\lib\site-packages\twspace_dl\__main__.py", line 34, in space
    log_filename = datetime.datetime.now().strftime(
ValueError: Invalid format string
```

Btw, the log file only write the last message like
```
2022-03-14 01:15:13,245 [INFO] Finished downloading
```
or
```
2022-03-14 01:17:14,383 [ERROR] Can't Download. Space has ended, can't retrieve master url. You can provide it with -f URL if you have it.
```
but in cmd screen even have like
```
2022-03-14 01:34:35,215 [INFO] ./[2022-03-12]creator_screen_name-id.m3u8 written to disk
2022-03-14 01:34:35,955 [INFO] .\tmppnmz5g9v\[2022-03-12]creator_screen_name-id.m3u8 written to disk
```
doesn't the two lines need write in log file, too?